### PR TITLE
save dead clients on stateful nodes and ensure their state files are removed

### DIFF
--- a/aggregator/src/aggregator.py
+++ b/aggregator/src/aggregator.py
@@ -7,6 +7,7 @@ from common.middleware import Middleware
 from common.packet import DataPacket, is_delete_packet, is_final_packet
 from common.atomic_write import atomic_write
 from common.worker_protocol import WorkerProtocol
+from common.dead_clients_tracker import DeadClientsTracker
 
 
 class AggregatorNode:
@@ -22,6 +23,7 @@ class AggregatorNode:
             queue=self.input_queue, consumer_tag=self.consumer_tag
         )
         self.output_rabbitmq = Middleware(queue=self.output_queue)
+        self.dead_clients_tracker = DeadClientsTracker()
 
         self.operation = os.getenv("operation", "total_invested")
 
@@ -45,18 +47,23 @@ class AggregatorNode:
             packet = json.loads(packet_json)
             header = packet.get("header")
             client_id = packet.get("client_id")
-            
+
             if header and is_delete_packet(header):
                 self.output_rabbitmq.send_delete(client_id=client_id)
+                self.dead_clients_tracker.set_client_as_dead(client_id)
                 self.delete_client(client_id)
                 ch.basic_ack(delivery_tag=method.delivery_tag)
                 return
-            
+
             if header and is_final_packet(header):
+                if self.dead_clients_tracker.client_is_dead(client_id):
+                    ch.basic_ack(delivery_tag=method.delivery_tag)
+                    return
                 self.send_results(client_id)
                 self.output_rabbitmq.send_final(client_id=client_id)
-                ch.basic_ack(delivery_tag=method.delivery_tag)
+                self.dead_clients_tracker.set_client_as_dead(client_id)
                 self.delete_client(client_id)
+                ch.basic_ack(delivery_tag=method.delivery_tag)
                 return
 
             packet = DataPacket.from_json(packet_json)

--- a/calculator/src/calculator.py
+++ b/calculator/src/calculator.py
@@ -3,7 +3,9 @@ import threading
 import os
 import signal
 import glob
+import logging
 from common.consistent_hash import consistent_hash
+from common.logger import init_logging
 from datetime import datetime
 from src.calculation import Calculation
 from common.leader_queue import LeaderQueue
@@ -12,6 +14,7 @@ from common.packet import DataPacket, is_delete_packet, is_final_packet
 from common.atomic_write import atomic_write
 from common.worker_protocol import WorkerProtocol
 
+init_logging(os.getenv("LOG_LEVEL", "info"))
 
 class CalculatorNode:
     def __init__(self):
@@ -40,6 +43,7 @@ class CalculatorNode:
         self.final_rabbitmq = None
         self.threads = []
         self.processed_messages_by_client = {}
+        self.dead_clients = set()
 
         self.leader_queue = None
         if int(self.node_id) == 0 and self.exchange != "router_negative_sentiment":
@@ -84,14 +88,20 @@ class CalculatorNode:
             packet = json.loads(packet_json)
             header = packet.get("header")
             client_id = packet.get("client_id")
-            
+
             if header and is_delete_packet(header):
                 self.output_rabbitmq.send_delete(client_id=client_id)
+                self.set_client_as_dead(client_id)
                 self.delete_client_data(client_id)
                 ch.basic_ack(delivery_tag=method.delivery_tag)
                 return
-                
+
             if header and is_final_packet(header):
+                # Ignore final packets from dead clients
+                if client_id in self.dead_clients:
+                    print("Received FINAL packet from dead client %s", client_id)
+                    ch.basic_ack(delivery_tag=method.delivery_tag)
+                    return
                 results = self.calculator.get_result(client_id)
                 self.output_rabbitmq.confirm_delivery()
 
@@ -121,8 +131,9 @@ class CalculatorNode:
                 self.final_rabbitmq.send_final_with_node_id(
                     client_id=client_id, count=count, node_id=node_id
                 )
-                ch.basic_ack(delivery_tag=method.delivery_tag)
+                self.set_client_as_dead(client_id)
                 self.delete_client_data(client_id)
+                ch.basic_ack(delivery_tag=method.delivery_tag)
                 return
 
             packet = DataPacket.from_json(packet_json)
@@ -175,6 +186,7 @@ class CalculatorNode:
         Starts the node, loading any previous state (if available)
         """
         self.load_state()
+        self.load_dead_clients_and_remove_leftover_files()
         try:
             self.input_rabbitmq.consume(self.callback)
         except Exception as e:
@@ -201,6 +213,12 @@ class CalculatorNode:
         # Save the state (atomically) to a file
         atomic_write(filename, data)
 
+    def set_client_as_dead(self, client_id):
+        self.dead_clients.add(client_id)
+        filename = "dead_clients.json"
+        content = json.dumps(list(self.dead_clients))
+        atomic_write(filename, content)
+
     def load_state(self):
         """
         Loads the state (partial result and processed messages) from disk, if available.
@@ -220,6 +238,30 @@ class CalculatorNode:
             print(
                 f"Recovered state from client {client_id}, len(processed_messages) = {len(self.processed_messages_by_client[client_id])}"
             )
+
+    def load_dead_clients_and_remove_leftover_files(self):
+        """
+        Attempts to load the dead clients from the dead_clients.json file.
+        It also checks for left over files for dead clients.
+        """
+
+        # Load the state
+        try:
+            with open("dead_clients.json", "r", encoding="utf-8") as f:
+                self.dead_clients = set(json.loads(f.read()))
+        except Exception as e:
+            logging.warning("Failed to read 'dead_clients.json' file. Error: %s", e)
+
+        # Look for left over files
+        for dead_client in self.dead_clients:
+            client_state_file = f"client.{dead_client}.json"
+            if os.path.exists(client_state_file):
+                logging.info("Client %s is dead but %s was not removed", dead_client, client_state_file)
+                try:
+                    os.remove(client_state_file)
+                    logging.info("Removed file %s", client_state_file)
+                except Exception as e:
+                    logging.error("Failed to remove file '%s'. Error: %s", client_state_file, e)
 
     def delete_client_data(self, client_id: int):
         """

--- a/calculator/src/calculator.py
+++ b/calculator/src/calculator.py
@@ -13,8 +13,10 @@ from common.middleware import Middleware
 from common.packet import DataPacket, is_delete_packet, is_final_packet
 from common.atomic_write import atomic_write
 from common.worker_protocol import WorkerProtocol
+from common.dead_clients_tracker import DeadClientsTracker
 
 init_logging(os.getenv("LOG_LEVEL", "info"))
+
 
 class CalculatorNode:
     def __init__(self):
@@ -43,7 +45,7 @@ class CalculatorNode:
         self.final_rabbitmq = None
         self.threads = []
         self.processed_messages_by_client = {}
-        self.dead_clients = set()
+        self.dead_clients_tracker = DeadClientsTracker()
 
         self.leader_queue = None
         if int(self.node_id) == 0 and self.exchange != "router_negative_sentiment":
@@ -91,14 +93,14 @@ class CalculatorNode:
 
             if header and is_delete_packet(header):
                 self.output_rabbitmq.send_delete(client_id=client_id)
-                self.set_client_as_dead(client_id)
+                self.dead_clients_tracker.set_client_as_dead(client_id)
                 self.delete_client_data(client_id)
                 ch.basic_ack(delivery_tag=method.delivery_tag)
                 return
 
             if header and is_final_packet(header):
                 # Ignore final packets from dead clients
-                if client_id in self.dead_clients:
+                if self.dead_clients_tracker.client_is_dead(client_id):
                     print("Received FINAL packet from dead client %s", client_id)
                     ch.basic_ack(delivery_tag=method.delivery_tag)
                     return
@@ -131,7 +133,7 @@ class CalculatorNode:
                 self.final_rabbitmq.send_final_with_node_id(
                     client_id=client_id, count=count, node_id=node_id
                 )
-                self.set_client_as_dead(client_id)
+                self.dead_clients_tracker.set_client_as_dead(client_id)
                 self.delete_client_data(client_id)
                 ch.basic_ack(delivery_tag=method.delivery_tag)
                 return
@@ -186,7 +188,6 @@ class CalculatorNode:
         Starts the node, loading any previous state (if available)
         """
         self.load_state()
-        self.load_dead_clients_and_remove_leftover_files()
         try:
             self.input_rabbitmq.consume(self.callback)
         except Exception as e:
@@ -213,12 +214,6 @@ class CalculatorNode:
         # Save the state (atomically) to a file
         atomic_write(filename, data)
 
-    def set_client_as_dead(self, client_id):
-        self.dead_clients.add(client_id)
-        filename = "dead_clients.json"
-        content = json.dumps(list(self.dead_clients))
-        atomic_write(filename, content)
-
     def load_state(self):
         """
         Loads the state (partial result and processed messages) from disk, if available.
@@ -238,30 +233,6 @@ class CalculatorNode:
             print(
                 f"Recovered state from client {client_id}, len(processed_messages) = {len(self.processed_messages_by_client[client_id])}"
             )
-
-    def load_dead_clients_and_remove_leftover_files(self):
-        """
-        Attempts to load the dead clients from the dead_clients.json file.
-        It also checks for left over files for dead clients.
-        """
-
-        # Load the state
-        try:
-            with open("dead_clients.json", "r", encoding="utf-8") as f:
-                self.dead_clients = set(json.loads(f.read()))
-        except Exception as e:
-            logging.warning("Failed to read 'dead_clients.json' file. Error: %s", e)
-
-        # Look for left over files
-        for dead_client in self.dead_clients:
-            client_state_file = f"client.{dead_client}.json"
-            if os.path.exists(client_state_file):
-                logging.info("Client %s is dead but %s was not removed", dead_client, client_state_file)
-                try:
-                    os.remove(client_state_file)
-                    logging.info("Removed file %s", client_state_file)
-                except Exception as e:
-                    logging.error("Failed to remove file '%s'. Error: %s", client_state_file, e)
 
     def delete_client_data(self, client_id: int):
         """

--- a/common/dead_clients_tracker.py
+++ b/common/dead_clients_tracker.py
@@ -1,0 +1,59 @@
+import os
+import json
+import logging
+from common.atomic_write import atomic_write
+
+DEAD_CLIENTS_FILE = "dead_clients.json"
+
+
+class DeadClientsTracker:
+    """
+    Tracks the dead clients
+    """
+
+    def __init__(self):
+        # Load the state
+        try:
+            with open("dead_clients.json", "r", encoding="utf-8") as f:
+                self.dead_clients = set(json.loads(f.read()))
+        except Exception as e:
+            logging.warning("Failed to read '%s' file. Error: %s", DEAD_CLIENTS_FILE, e)
+            self.dead_clients = set()
+
+    def set_client_as_dead(self, client_id):
+        """
+        Sets the given client as dead
+        """
+        self.dead_clients.add(client_id)
+        content = json.dumps(list(self.dead_clients))
+        atomic_write(DEAD_CLIENTS_FILE, content)
+
+    def client_is_dead(self, client_id):
+        """
+        Returns whether the given client is dead
+        """
+        return client_id in self.dead_clients
+
+    def remove_left_over_files(self):
+        """
+        Removes the left over client state files
+
+        NOTE: the left over files are searched as 'client.*.json'.
+        """
+        # Look for left over files
+        for dead_client in self.dead_clients:
+            client_state_file = f"client.{dead_client}.json"
+            if not os.path.exists(client_state_file):
+                continue
+            logging.info(
+                "Client %s is dead but %s was not removed",
+                dead_client,
+                client_state_file,
+            )
+            try:
+                os.remove(client_state_file)
+                logging.info("Removed file %s", client_state_file)
+            except Exception as e:
+                logging.error(
+                    "Failed to remove file '%s'. Error: %s", client_state_file, e
+                )

--- a/common/dead_clients_tracker.py
+++ b/common/dead_clients_tracker.py
@@ -8,13 +8,17 @@ DEAD_CLIENTS_FILE = "dead_clients.json"
 
 class DeadClientsTracker:
     """
-    Tracks the dead clients
+    Tracks the dead clients and performs cleanup
+    of dead client files.
     """
 
     def __init__(self):
-        # Load the state
+        """
+        Tries to load the dead clients from the DEAD_CLIENTS_FILE,
+        and looks for dead client state files to remove (and removes them if there are any)
+        """
         try:
-            with open("dead_clients.json", "r", encoding="utf-8") as f:
+            with open(DEAD_CLIENTS_FILE, "r", encoding="utf-8") as f:
                 self.dead_clients = set(json.loads(f.read()))
         except Exception as e:
             logging.warning("Failed to read '%s' file. Error: %s", DEAD_CLIENTS_FILE, e)
@@ -47,14 +51,14 @@ class DeadClientsTracker:
             client_state_file = f"client.{dead_client}.json"
             if not os.path.exists(client_state_file):
                 continue
-            logging.info(
+            logging.debug(
                 "Client %s is dead but %s was not removed",
                 dead_client,
                 client_state_file,
             )
             try:
                 os.remove(client_state_file)
-                logging.info("Removed file %s", client_state_file)
+                logging.debug("Removed file %s", client_state_file)
             except Exception as e:
                 logging.error(
                     "Failed to remove file '%s'. Error: %s", client_state_file, e

--- a/common/dead_clients_tracker.py
+++ b/common/dead_clients_tracker.py
@@ -20,6 +20,8 @@ class DeadClientsTracker:
             logging.warning("Failed to read '%s' file. Error: %s", DEAD_CLIENTS_FILE, e)
             self.dead_clients = set()
 
+        self._remove_leftover_files()
+
     def set_client_as_dead(self, client_id):
         """
         Sets the given client as dead
@@ -34,7 +36,7 @@ class DeadClientsTracker:
         """
         return client_id in self.dead_clients
 
-    def remove_left_over_files(self):
+    def _remove_leftover_files(self):
         """
         Removes the left over client state files
 

--- a/deliver/src/deliver.py
+++ b/deliver/src/deliver.py
@@ -8,6 +8,7 @@ from common.leader_queue import LeaderQueue
 from common.packet import DataPacket, QueryPacket, is_delete_packet, is_final_packet
 from common.middleware import Middleware
 from common.worker_protocol import WorkerProtocol
+from common.dead_clients_tracker import DeadClientsTracker
 
 
 class DeliverNode:
@@ -44,6 +45,7 @@ class DeliverNode:
         self.control = WorkerProtocol(
             self.health_server_ip, self.health_server_port, self.health_server_port
         )
+        self.dead_clients_tracker = DeadClientsTracker()
 
     def callback(self, ch, method, properties, body):
         try:
@@ -55,14 +57,20 @@ class DeliverNode:
             packet = json.loads(body_decoded)
             header = packet.get("header")
             client_id = packet.get("client_id")
-            
+
             if header and is_delete_packet(header):
-                self.final_rabbitmq.send_delete_with_node_id(client_id=client_id, node_id=self.query_number)
+                self.final_rabbitmq.send_delete_with_node_id(
+                    client_id=client_id, node_id=self.query_number
+                )
+                self.dead_clients_tracker.set_client_as_dead(client_id)
                 self.delete_client_data(client_id)
                 ch.basic_ack(delivery_tag=method.delivery_tag)
                 return
-            
+
             if header and is_final_packet(header):
+                if self.dead_clients_tracker.client_is_dead(client_id):
+                    ch.basic_ack(delivery_tag=method.delivery_tag)
+                    return
                 final_response = self.generate_final_response(client_id)
                 final_response_str = json.dumps(
                     {"response": final_response}, ensure_ascii=False
@@ -76,8 +84,9 @@ class DeliverNode:
                 self.final_rabbitmq.send_final_with_node_id(
                     client_id=int(client_id), node_id=self.query_number, count=1
                 )
-                ch.basic_ack(delivery_tag=method.delivery_tag)
+                self.dead_clients_tracker.set_client_as_dead(client_id)
                 self.delete_client_data(client_id)
+                ch.basic_ack(delivery_tag=method.delivery_tag)
                 return
 
             packet = DataPacket.from_json(body_decoded)


### PR DESCRIPTION
* Agrega el modulo `dead_clients_tracker` que provee primitivas para trackear clientes muertos.
    * Este modulo permite asegurarnos la limpieza de los datos de los clientes muertos.
    * Se persiste en disco una lista con los IDs de los clientes muertos.
    * Si el nodo se cae, al reiniciarse este módulo va a eliminar los archivos que hayan quedado de clientes muertos. Esto es particularmente útil si el nodo se cae justo antes de eliminar los datos de un cliente.
    * Periódicamente se van borrando los IDs de los clientes muertos.