### PR TITLE
adapt `DeadClientsTracker` for the join node

### DIFF
--- a/aggregator/src/aggregator.py
+++ b/aggregator/src/aggregator.py
@@ -23,7 +23,7 @@ class AggregatorNode:
             queue=self.input_queue, consumer_tag=self.consumer_tag
         )
         self.output_rabbitmq = Middleware(queue=self.output_queue)
-        self.dead_clients_tracker = DeadClientsTracker(is_join_node=False)
+        self.dead_clients_tracker = DeadClientsTracker(is_join_node=False, node_id=0)
 
         self.operation = os.getenv("operation", "total_invested")
 

--- a/aggregator/src/aggregator.py
+++ b/aggregator/src/aggregator.py
@@ -23,7 +23,7 @@ class AggregatorNode:
             queue=self.input_queue, consumer_tag=self.consumer_tag
         )
         self.output_rabbitmq = Middleware(queue=self.output_queue)
-        self.dead_clients_tracker = DeadClientsTracker()
+        self.dead_clients_tracker = DeadClientsTracker(is_join_node=False)
 
         self.operation = os.getenv("operation", "total_invested")
 

--- a/calculator/src/calculator.py
+++ b/calculator/src/calculator.py
@@ -45,7 +45,7 @@ class CalculatorNode:
         self.final_rabbitmq = None
         self.threads = []
         self.processed_messages_by_client = {}
-        self.dead_clients_tracker = DeadClientsTracker(is_join_node=False)
+        self.dead_clients_tracker = DeadClientsTracker(is_join_node=False, node_id=self.node_id)
 
         self.leader_queue = None
         if int(self.node_id) == 0 and self.exchange != "router_negative_sentiment":

--- a/calculator/src/calculator.py
+++ b/calculator/src/calculator.py
@@ -45,7 +45,7 @@ class CalculatorNode:
         self.final_rabbitmq = None
         self.threads = []
         self.processed_messages_by_client = {}
-        self.dead_clients_tracker = DeadClientsTracker()
+        self.dead_clients_tracker = DeadClientsTracker(is_join_node=False)
 
         self.leader_queue = None
         if int(self.node_id) == 0 and self.exchange != "router_negative_sentiment":

--- a/common/dead_clients_tracker.py
+++ b/common/dead_clients_tracker.py
@@ -1,6 +1,7 @@
 import os
 import json
 import logging
+import threading
 from common.atomic_write import atomic_write
 
 DEAD_CLIENTS_FILE = "dead_clients.json"
@@ -17,8 +18,11 @@ class DeadClientsTracker:
         """
         Tries to load the dead clients from the DEAD_CLIENTS_FILE,
         and looks for dead client state files to remove (and removes them if there are any)
+
+        This object may be accessed concurrently so we make it thread-safe by adding a lock
         """
         self.max_size = MAX_SIZE
+        self.lock = threading.Lock()
         try:
             with open(DEAD_CLIENTS_FILE, "r", encoding="utf-8") as f:
                 self.dead_clients = json.loads(f.read())
@@ -32,18 +36,20 @@ class DeadClientsTracker:
         """
         Sets the given client as dead
         """
-        self.dead_clients.append(client_id)
-        # Delete stale data
-        if len(self.dead_clients) > self.max_size:
-            self.dead_clients = self.dead_clients[MAX_SIZE // 10 :]
-        content = json.dumps(self.dead_clients)
-        atomic_write(DEAD_CLIENTS_FILE, content)
+        with self.lock:
+            self.dead_clients.append(client_id)
+            # Delete stale data
+            if len(self.dead_clients) > self.max_size:
+                self.dead_clients = self.dead_clients[MAX_SIZE // 10 :]
+            content = json.dumps(self.dead_clients)
+            atomic_write(DEAD_CLIENTS_FILE, content)
 
     def client_is_dead(self, client_id):
         """
         Returns whether the given client is dead
         """
-        return client_id in self.dead_clients
+        with self.lock:
+            return client_id in self.dead_clients
 
     def _remove_leftover_files(self):
         """

--- a/common/dead_clients_tracker.py
+++ b/common/dead_clients_tracker.py
@@ -14,7 +14,7 @@ class DeadClientsTracker:
     of dead client files.
     """
 
-    def __init__(self):
+    def __init__(self, is_join_node: bool):
         """
         Tries to load the dead clients from the DEAD_CLIENTS_FILE,
         and looks for dead client state files to remove (and removes them if there are any)
@@ -23,14 +23,17 @@ class DeadClientsTracker:
         """
         self.max_size = MAX_SIZE
         self.lock = threading.Lock()
+        self.is_join_node = is_join_node
         try:
             with open(DEAD_CLIENTS_FILE, "r", encoding="utf-8") as f:
                 self.dead_clients = json.loads(f.read())
         except Exception as e:
             logging.warning("Failed to read '%s' file. Error: %s", DEAD_CLIENTS_FILE, e)
             self.dead_clients = []
-
-        self._remove_leftover_files()
+        if self.is_join_node:
+            self._remove_join_leftover_files()
+        else:
+            self._remove_leftover_files()
 
     def set_client_as_dead(self, client_id):
         """
@@ -74,3 +77,9 @@ class DeadClientsTracker:
                 logging.error(
                     "Failed to remove file '%s'. Error: %s", client_state_file, e
                 )
+
+    def _remove_join_leftover_files(self):
+        """
+        """
+        # TODO
+        pass 

--- a/common/dead_clients_tracker.py
+++ b/common/dead_clients_tracker.py
@@ -2,6 +2,7 @@ import os
 import json
 import logging
 import threading
+import shutil
 from common.atomic_write import atomic_write
 
 DEAD_CLIENTS_FILE = "dead_clients.json"
@@ -12,9 +13,11 @@ class DeadClientsTracker:
     """
     Tracks the dead clients and performs cleanup
     of dead client files.
+
+    node_id is only required for the join node
     """
 
-    def __init__(self, is_join_node: bool):
+    def __init__(self, is_join_node: bool, node_id: int):
         """
         Tries to load the dead clients from the DEAD_CLIENTS_FILE,
         and looks for dead client state files to remove (and removes them if there are any)
@@ -25,6 +28,7 @@ class DeadClientsTracker:
         self.max_size = MAX_SIZE
         self.lock = threading.Lock()
         self.is_join_node = is_join_node
+        self.node_id = node_id
         try:
             with open(DEAD_CLIENTS_FILE, "r", encoding="utf-8") as f:
                 self.dead_clients = json.loads(f.read())
@@ -56,7 +60,7 @@ class DeadClientsTracker:
     def _remove_leftover_files(self):
         """
         Removes the left over client state files
-        
+
         There is no need to use the lock here since this is only
         called when the node initializes (not concurrent)
         """
@@ -80,3 +84,10 @@ class DeadClientsTracker:
                 logging.error(
                     "Failed to remove file '%s'. Error: %s", client_state_file, e
                 )
+            if self.is_join_node:
+                try:
+                    client_directory = f"storage_{self.node_id}_{dead_client}"
+                    shutil.rmtree(client_directory)
+                    logging.info("Removed %s directory", client_directory)
+                except Exception as e:
+                    logging.warning("Failed to remove directory %s. Error: %s", client_directory, e)

--- a/common/dead_clients_tracker.py
+++ b/common/dead_clients_tracker.py
@@ -19,7 +19,8 @@ class DeadClientsTracker:
         Tries to load the dead clients from the DEAD_CLIENTS_FILE,
         and looks for dead client state files to remove (and removes them if there are any)
 
-        This object may be accessed concurrently so we make it thread-safe by adding a lock
+        This object may be accessed concurrently (e.g. in the join node) so we make it 
+        thread-safe by adding a lock
         """
         self.max_size = MAX_SIZE
         self.lock = threading.Lock()
@@ -30,10 +31,8 @@ class DeadClientsTracker:
         except Exception as e:
             logging.warning("Failed to read '%s' file. Error: %s", DEAD_CLIENTS_FILE, e)
             self.dead_clients = []
-        if self.is_join_node:
-            self._remove_join_leftover_files()
-        else:
-            self._remove_leftover_files()
+
+        self._remove_leftover_files()
 
     def set_client_as_dead(self, client_id):
         """
@@ -57,12 +56,16 @@ class DeadClientsTracker:
     def _remove_leftover_files(self):
         """
         Removes the left over client state files
-
-        NOTE: the left over files are searched as 'client.*.json'.
+        
+        There is no need to use the lock here since this is only
+        called when the node initializes (not concurrent)
         """
         # Look for left over files
         for dead_client in self.dead_clients:
-            client_state_file = f"client.{dead_client}.json"
+            if self.is_join_node:
+                client_state_file = f"state.client.{dead_client}.json"
+            else:
+                client_state_file = f"client.{dead_client}.json"
             if not os.path.exists(client_state_file):
                 continue
             logging.debug(
@@ -77,9 +80,3 @@ class DeadClientsTracker:
                 logging.error(
                     "Failed to remove file '%s'. Error: %s", client_state_file, e
                 )
-
-    def _remove_join_leftover_files(self):
-        """
-        """
-        # TODO
-        pass 

--- a/deliver/src/deliver.py
+++ b/deliver/src/deliver.py
@@ -45,7 +45,7 @@ class DeliverNode:
         self.control = WorkerProtocol(
             self.health_server_ip, self.health_server_port, self.health_server_port
         )
-        self.dead_clients_tracker = DeadClientsTracker(is_join_node=False)
+        self.dead_clients_tracker = DeadClientsTracker(is_join_node=False, node_id=self.query_number)
 
     def callback(self, ch, method, properties, body):
         try:

--- a/deliver/src/deliver.py
+++ b/deliver/src/deliver.py
@@ -45,7 +45,7 @@ class DeliverNode:
         self.control = WorkerProtocol(
             self.health_server_ip, self.health_server_port, self.health_server_port
         )
-        self.dead_clients_tracker = DeadClientsTracker()
+        self.dead_clients_tracker = DeadClientsTracker(is_join_node=False)
 
     def callback(self, ch, method, properties, body):
         try:

--- a/join/src/join.py
+++ b/join/src/join.py
@@ -48,7 +48,7 @@ class JoinNode:
         self.packets_sent_by_client = {}
         self.processed_messages_by_client = {}
         self.processed_messages_by_client_queue_2 = {}
-        self.dead_clients_tracker = DeadClientsTracker(is_join_node=True)
+        self.dead_clients_tracker = DeadClientsTracker(is_join_node=True, node_id=self.node_id)
 
         self.keep_columns = None
         keep_columns = os.getenv("KEEP_COLUMNS", "")

--- a/join/src/join.py
+++ b/join/src/join.py
@@ -48,7 +48,7 @@ class JoinNode:
         self.packets_sent_by_client = {}
         self.processed_messages_by_client = {}
         self.processed_messages_by_client_queue_2 = {}
-        self.dead_clients_tracker = DeadClientsTracker()
+        self.dead_clients_tracker = DeadClientsTracker(is_join_node=True)
 
         self.keep_columns = None
         keep_columns = os.getenv("KEEP_COLUMNS", "")


### PR DESCRIPTION
Adapta la clase `DeadClientsTracker` para que funcione con en nodo join. Esto incluye
* Agregar un lock para que el acceso a la clase sea thread-safe.
* Eliminar los storages de los clientes muertos del nodo join.